### PR TITLE
function connect() Fix

### DIFF
--- a/www/includes/DB/mysql.php
+++ b/www/includes/DB/mysql.php
@@ -55,7 +55,7 @@ function connect($force_select = false) {
 	}
 
 	$host = !$this->dbport ? $this->dbhost : "$this->dbhost:$this->dbport";
-	$this->dbh = @mysqli_connect($host, $this->dbuser, $this->dbpass, $this->dbname);
+	$this->dbh = @mysqli_connect($host, $this->dbuser, $this->dbpass); // remove @ from mysqli_connect to see errors
 	$this->connected = ($this->dbh);
 	if ($this->connected and (!$this->conf['delaydb'] or $force_select)) {
 		$this->selected = $this->selectdb();


### PR DESCRIPTION
removed unneeded parameter from mysqli command so that installer can pass Database Setup checks.

![image](https://user-images.githubusercontent.com/4959837/118339555-782da800-b519-11eb-96c4-041d65cec0c3.png)
